### PR TITLE
drivers: ad717x: Fix AD717X_WaitForReady()

### DIFF
--- a/drivers/ad717x/ad717x.c
+++ b/drivers/ad717x/ad717x.c
@@ -261,7 +261,7 @@ int32_t AD717X_WaitForReady(struct ad717x_device *device, uint32_t timeout)
 			return ret;
 
 		/* Check the RDY bit in the Status Register */
-		ready = (statusReg->value & AD717X_STATUS_REG_RDY) != 0;
+		ready = (statusReg->value & AD717X_STATUS_REG_RDY) == 0;
 	}
 
 	return timeout ? 0 : TIMEOUT;


### PR DESCRIPTION
The RDY bit goes low when the ADC has written a new result to the data register.